### PR TITLE
[feat] company 기능 및 응답 통일 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'io.github.cdimascio:dotenv-spring-boot:3.0.0' //env 파일을 불러오게 함
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0' //swagger 설정
 }
 

--- a/src/main/java/N0tice_Project/N0tice_BE/company/controller/CompanyController.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/controller/CompanyController.java
@@ -22,7 +22,7 @@ public class CompanyController {
 
     @GetMapping("/search")
     public ApiResponse<List<CompanyResponse>> searchCompanies(
-            @RequestParam String keyword) {
+            @RequestParam("keyword") String keyword) {
 
         List<Company> companies = companyService.searchCompanies(keyword);
 
@@ -36,9 +36,9 @@ public class CompanyController {
     // 시, 구, 동으로 검색
     @GetMapping("/location")
     public ApiResponse<List<CompanyResponse>> searchCompaniesByLocation(
-            @RequestParam String city,
-            @RequestParam String district,
-            @RequestParam String neighborhood) {
+            @RequestParam("city") String city,
+            @RequestParam("district") String district,
+            @RequestParam("neighborhood") String neighborhood) {
 
         List<Company> companies = companyService.searchCompaniesByLocation(city, district, neighborhood);
 

--- a/src/main/java/N0tice_Project/N0tice_BE/company/controller/CompanyController.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/controller/CompanyController.java
@@ -1,4 +1,51 @@
 package N0tice_Project.N0tice_BE.company.controller;
 
+import N0tice_Project.N0tice_BE.company.domain.Company;
+import N0tice_Project.N0tice_BE.company.dto.CompanyResponse;
+import N0tice_Project.N0tice_BE.company.service.CompanyService;
+import N0tice_Project.N0tice_BE.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/companies")
+@RequiredArgsConstructor
 public class CompanyController {
+    private final CompanyService companyService;
+
+    @GetMapping("/search")
+    public ApiResponse<List<CompanyResponse>> searchCompanies(
+            @RequestParam String keyword) {
+
+        List<Company> companies = companyService.searchCompanies(keyword);
+
+        List<CompanyResponse> dtoList = companies.stream()
+                .map(CompanyResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(dtoList);
+    }
+
+    // 시, 구, 동으로 검색
+    @GetMapping("/location")
+    public ApiResponse<List<CompanyResponse>> searchCompaniesByLocation(
+            @RequestParam String city,
+            @RequestParam String district,
+            @RequestParam String neighborhood) {
+
+        List<Company> companies = companyService.searchCompaniesByLocation(city, district, neighborhood);
+
+        List<CompanyResponse> dtoList = companies.stream()
+                .map(CompanyResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(dtoList);
+    }
 }

--- a/src/main/java/N0tice_Project/N0tice_BE/company/domain/AccidentType.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/domain/AccidentType.java
@@ -1,4 +1,17 @@
 package N0tice_Project.N0tice_BE.company.domain;
 
 public enum AccidentType {
+    CONCEALMENT("은폐"), // 은폐
+    DEATH("사망"),       // 사망
+    INJURY("부상");      // 부상
+
+    private final String displayName;
+
+    AccidentType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/N0tice_Project/N0tice_BE/company/domain/AccidentType.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/domain/AccidentType.java
@@ -1,0 +1,4 @@
+package N0tice_Project.N0tice_BE.company.domain;
+
+public enum AccidentType {
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/company/domain/Company.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/domain/Company.java
@@ -28,6 +28,7 @@ public class Company {
     private String addressDistrict;
     private String addressNeighborhood;
 
+    @Enumerated(EnumType.STRING) // Enum 값을 문자열로 DB에 저장
     @Column(nullable = false)
-    private String accidentType;
+    private AccidentType accidentType; // string -> enum 타입 변경
 }

--- a/src/main/java/N0tice_Project/N0tice_BE/company/dto/CompanyRequest.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/dto/CompanyRequest.java
@@ -1,4 +1,0 @@
-package N0tice_Project.N0tice_BE.company.dto;
-
-public class CompanyRequest {
-}

--- a/src/main/java/N0tice_Project/N0tice_BE/company/dto/CompanyResponse.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/dto/CompanyResponse.java
@@ -1,4 +1,31 @@
 package N0tice_Project.N0tice_BE.company.dto;
 
+import N0tice_Project.N0tice_BE.company.domain.AccidentType;
+import N0tice_Project.N0tice_BE.company.domain.Company;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CompanyResponse {
+
+    private String companyName;
+    private Integer dataYear;
+    private String address;
+    private String accidentType; // string으로 반환
+
+    public static CompanyResponse fromEntity(Company company) {
+        if (company == null) return null;
+        return CompanyResponse.builder()
+                .companyName(company.getCompanyName())
+                .dataYear(company.getDataYear())
+                .address(company.getAddress())
+                .accidentType(company.getAccidentType() != null ? company.getAccidentType().getDisplayName() : null)
+                .build();
+    }
 }
+

--- a/src/main/java/N0tice_Project/N0tice_BE/company/repository/CompanyRepository.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/repository/CompanyRepository.java
@@ -1,4 +1,15 @@
 package N0tice_Project.N0tice_BE.company.repository;
 
-public interface CompanyRepository {
+import N0tice_Project.N0tice_BE.company.domain.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+    // 메소드 이름 규칙을 사용한 쿼리 생성
+    // Containing: SQL의 LIKE %keyword%
+    List<Company> findByCompanyNameContaining(String keyword);
+
+    // 새로운 쿼리 메소드 (시, 구, 동으로 검색)
+    List<Company> findByAddressCityAndAddressDistrictAndAddressNeighborhood(String addressCity, String addressDistrict, String addressNeighborhood);
 }

--- a/src/main/java/N0tice_Project/N0tice_BE/company/service/CompanyService.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/company/service/CompanyService.java
@@ -1,4 +1,35 @@
 package N0tice_Project.N0tice_BE.company.service;
 
+import N0tice_Project.N0tice_BE.company.domain.Company;
+import N0tice_Project.N0tice_BE.company.repository.CompanyRepository;
+import N0tice_Project.N0tice_BE.global.exception.GeneralException;
+import N0tice_Project.N0tice_BE.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+// 리포지토리에 단순히 위임만 하는 클래스
+@Service
+@RequiredArgsConstructor
 public class CompanyService {
+    private final CompanyRepository companyRepository;
+
+    // 사업장명 검색
+    public List<Company> searchCompanies(String keyword) {
+        List<Company> companies = companyRepository.findByCompanyNameContaining(keyword);
+        if (companies == null || companies.isEmpty()) {
+            throw new GeneralException(ErrorStatus.COMPANY_NOT_FOUND);
+        }
+        return companies;
+    }
+
+    // 시, 구, 동으로 검색
+    public List<Company> searchCompaniesByLocation(String city, String district, String neighborhood) {
+        List<Company> companies = companyRepository.findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood);
+        if (companies == null || companies.isEmpty()) {
+            throw new GeneralException(ErrorStatus.NO_SEARCH_RESULT);
+        }
+        return companies;
+    }
 }

--- a/src/main/java/N0tice_Project/N0tice_BE/global/ApiResponse.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/ApiResponse.java
@@ -1,0 +1,36 @@
+package N0tice_Project.N0tice_BE.global;
+
+import N0tice_Project.N0tice_BE.global.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"}) // JSON 응답의 필드 순서를 명시적으로 지정
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T data){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), data);
+    }
+
+    // BaseCode를 받아 성공 및 실패 응답을 모두 처리
+    public static <T> ApiResponse<T> of(BaseCode code, T data){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), data);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/BaseCode.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/BaseCode.java
@@ -1,0 +1,6 @@
+package N0tice_Project.N0tice_BE.global;
+
+public interface BaseCode {
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/ReasonDTO.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/ReasonDTO.java
@@ -1,0 +1,17 @@
+package N0tice_Project.N0tice_BE.global;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){ return isSuccess; }
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/exception/ExceptionAdvice.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/exception/ExceptionAdvice.java
@@ -1,0 +1,89 @@
+package N0tice_Project.N0tice_BE.global.exception;
+
+import N0tice_Project.N0tice_BE.global.ApiResponse;
+import N0tice_Project.N0tice_BE.global.ReasonDTO;
+import N0tice_Project.N0tice_BE.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j // 로깅을 위한 Lombok 어노테이션
+@RestControllerAdvice(annotations = {RestController.class}) // 모든 @RestController에서 발생하는 예외를 처리
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    // 1. ConstraintViolationException 처리 (Bean Validation에서 발생하는 예외)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        log.warn("ConstraintViolationException: " + e.getMessage(), e);
+
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(cv -> cv.getMessage())
+                .findFirst()
+                .orElse(ErrorStatus._BAD_REQUEST.getMessage()); // 에러 메시지 추출
+
+        ApiResponse<Object> body = ApiResponse.onFailure(ErrorStatus._BAD_REQUEST.getCode(), errorMessage, null);
+
+        return handleExceptionInternal(e, body, HttpHeaders.EMPTY, ErrorStatus._BAD_REQUEST.getHttpStatus(), request);
+    }
+
+    // 2. MethodArgumentNotValidException 처리 (@Valid 어노테이션에서 발생하는 예외)
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
+
+        log.warn("MethodArgumentNotValidException: " + errors, ex); // 로깅
+        ApiResponse<Object> body = ApiResponse.onFailure(ErrorStatus._BAD_REQUEST.getCode(), ErrorStatus._BAD_REQUEST.getMessage(), errors);
+        return handleExceptionInternal(ex, body, headers, ErrorStatus._BAD_REQUEST.getHttpStatus(), request);
+    }
+
+    // 3. 일반 Exception 처리 (처리되지 않은 모든 예외)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        log.error("Exception: ", e); // 스택 트레이스 로깅
+        String errorMessage = "알 수 없는 오류가 발생했습니다."; // 일반적인 오류 메시지
+        ApiResponse<Object> body = ApiResponse.onFailure(ErrorStatus._INTERNAL_SERVER_ERROR.getCode(), errorMessage, null);
+        return handleExceptionInternal(e, body, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request);
+    }
+
+    // 4. 사용자 정의 예외(GeneralException) 처리
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity<Object> onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        ApiResponse<Object> body = ApiResponse.onFailure(errorReasonHttpStatus.getCode(), errorReasonHttpStatus.getMessage(), null);
+        return handleExceptionInternal(generalException, body, null, errorReasonHttpStatus.getHttpStatus(), new ServletWebRequest(request));
+    }
+
+    // 5. handleExceptionInternal 커스텀 메서드 (Spring의 handleExceptionInternal을 확장하여 ApiResponse를 본문으로 사용)
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ApiResponse<Object> body,
+                                                           HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/exception/GeneralException.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/exception/GeneralException.java
@@ -1,0 +1,16 @@
+package N0tice_Project.N0tice_BE.global.exception;
+
+import N0tice_Project.N0tice_BE.global.BaseCode;
+import N0tice_Project.N0tice_BE.global.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+    private BaseCode code;
+
+    public ReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/status/ErrorStatus.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/status/ErrorStatus.java
@@ -1,0 +1,36 @@
+package N0tice_Project.N0tice_BE.global.status;
+
+import N0tice_Project.N0tice_BE.global.BaseCode;
+import N0tice_Project.N0tice_BE.global.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseCode {
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // Company 관련 에러 코드 추가
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY404", "해당 회사를 찾을 수 없습니다."),
+    NO_SEARCH_RESULT(HttpStatus.NOT_FOUND, "COMPANY404", "검색 결과가 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+    @Override
+    public ReasonDTO getReasonHttpStatus(){
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/N0tice_Project/N0tice_BE/global/status/SuccessStatus.java
+++ b/src/main/java/N0tice_Project/N0tice_BE/global/status/SuccessStatus.java
@@ -1,0 +1,27 @@
+package N0tice_Project.N0tice_BE.global.status;
+
+import N0tice_Project.N0tice_BE.global.BaseCode;
+import N0tice_Project.N0tice_BE.global.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReasonHttpStatus(){
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/test/java/N0tice_Project/N0tice_BE/company/CompanyServiceTest.java
+++ b/src/test/java/N0tice_Project/N0tice_BE/company/CompanyServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class CompanyServiceTest {
+  
+}

--- a/src/test/java/N0tice_Project/N0tice_BE/company/CompanyServiceTest.java
+++ b/src/test/java/N0tice_Project/N0tice_BE/company/CompanyServiceTest.java
@@ -1,4 +1,150 @@
-import static org.junit.jupiter.api.Assertions.*;
+package N0tice_Project.N0tice_BE.company;
+
+import N0tice_Project.N0tice_BE.company.domain.AccidentType;
+import N0tice_Project.N0tice_BE.company.domain.Company;
+import N0tice_Project.N0tice_BE.company.repository.CompanyRepository;
+import N0tice_Project.N0tice_BE.company.service.CompanyService;
+import N0tice_Project.N0tice_BE.global.exception.GeneralException;
+import N0tice_Project.N0tice_BE.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+@ExtendWith(MockitoExtension.class) // Mockito 확장 기능을 사용하기 위한 어노테이션
 class CompanyServiceTest {
-  
+    @Mock // 협력자(가짜 객체)
+    private CompanyRepository companyRepository;
+
+    @InjectMocks // 테스트 주체 (companyRepository Mock 객체가 주입됨)
+    private CompanyService companyService;
+
+    @Test
+    @DisplayName("사업장명으로 회사 검색 성공")
+    void searchCompanies_성공() {
+        // Given: 테스트를 진행할 행위를 위한 사전 준비
+        String keyword = "테스트";
+        Company company1 = Company.builder().companyName("테스트회사1").accidentType(AccidentType.DEATH).build();
+        Company company2 = Company.builder().companyName("다른테스트회사").accidentType(AccidentType.INJURY).build();
+        List<Company> expectedCompanies = Arrays.asList(company1, company2);
+
+        // companyRepository.findByCompanyNameContaining(keyword)가 호출되면 expectedCompanies를 반환하도록 설정
+        given(companyRepository.findByCompanyNameContaining(keyword)).willReturn(expectedCompanies);
+
+        // When: 테스트를 진행할 행위
+        List<Company> actualCompanies = companyService.searchCompanies(keyword);
+
+        // Then: 테스트를 진행한 행위에 대한 결과 검증
+        assertThat(actualCompanies).isNotNull();
+        assertThat(actualCompanies.size()).isEqualTo(2);
+        assertThat(actualCompanies).isEqualTo(expectedCompanies); // 객체 내용 비교
+        verify(companyRepository).findByCompanyNameContaining(keyword); // companyRepository의 메소드가 호출되었는지 검증
+    }
+
+    @Test
+    @DisplayName("사업장명으로 회사 검색 결과 없음 - 예외 발생")
+    void searchCompanies_결과없음_예외발생() {
+        // Given
+        String keyword = "없는회사";
+        // companyRepository.findByCompanyNameContaining(keyword)가 호출되면 빈 리스트를 반환하도록 설정
+        given(companyRepository.findByCompanyNameContaining(keyword)).willReturn(Collections.emptyList());
+
+        // When & Then
+        assertThatThrownBy(() -> companyService.searchCompanies(keyword))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code") // "code" 프로퍼티(getter)를 통해 값을 추출
+                .isEqualTo(ErrorStatus.COMPANY_NOT_FOUND); // 예외 내부의 errorStatus 검증
+
+        verify(companyRepository).findByCompanyNameContaining(keyword);
+    }
+
+    @Test
+    @DisplayName("사업장명으로 회사 검색 시 Repository 반환값이 null인 경우 - 예외 발생")
+    void searchCompanies_RepositoryNull반환_예외발생() {
+        // Given
+        String keyword = "테스트";
+        // companyRepository.findByCompanyNameContaining(keyword)가 호출되면 null을 반환하도록 설정
+        given(companyRepository.findByCompanyNameContaining(keyword)).willReturn(null);
+
+        // When & Then
+        assertThatThrownBy(() -> companyService.searchCompanies(keyword))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code") // "code" 프로퍼티(getter)를 통해 값을 추출
+                .isEqualTo(ErrorStatus.COMPANY_NOT_FOUND); // 예외 내부의 errorStatus 검증
+
+        verify(companyRepository).findByCompanyNameContaining(keyword);
+    }
+
+    @Test
+    @DisplayName("시, 구, 동으로 회사 검색 성공")
+    void searchCompaniesByLocation_성공() {
+        // Given
+        String city = "서울특별시";
+        String district = "강남구";
+        String neighborhood = "역삼동";
+        Company company1 = Company.builder().addressCity(city).addressDistrict(district).addressNeighborhood(neighborhood).companyName("강남점").accidentType(AccidentType.DEATH).build();
+        List<Company> expectedCompanies = Collections.singletonList(company1);
+
+        given(companyRepository.findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood))
+                .willReturn(expectedCompanies);
+
+        // When
+        List<Company> actualCompanies = companyService.searchCompaniesByLocation(city, district, neighborhood);
+
+        // Then
+        assertThat(actualCompanies).isNotNull();
+        assertThat(actualCompanies.size()).isEqualTo(1);
+        assertThat(actualCompanies.get(0).getCompanyName()).isEqualTo("강남점");
+        verify(companyRepository).findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood);
+    }
+
+    @Test
+    @DisplayName("시, 구, 동으로 회사 검색 결과 없음 - 예외 발생")
+    void searchCompaniesByLocation_결과없음_예외발생() {
+        // Given
+        String city = "부산광역시";
+        String district = "해운대구";
+        String neighborhood = "우동";
+        given(companyRepository.findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood))
+                .willReturn(Collections.emptyList());
+
+        // When & Then
+        assertThatThrownBy(() -> companyService.searchCompaniesByLocation(city, district, neighborhood))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code") // "code" 프로퍼티(getter)를 통해 값을 추출
+                .isEqualTo(ErrorStatus.NO_SEARCH_RESULT); // 예외 내부의 errorStatus 검증
+
+        verify(companyRepository).findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood);
+    }
+
+    @Test
+    @DisplayName("시, 구, 동으로 회사 검색 시 Repository 반환값이 null인 경우 - 예외 발생")
+    void searchCompaniesByLocation_RepositoryNull반환_예외발생() {
+        // Given
+        String city = "서울특별시";
+        String district = "강남구";
+        String neighborhood = "역삼동";
+        given(companyRepository.findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood))
+                .willReturn(null);
+
+        // When & Then
+        assertThatThrownBy(() -> companyService.searchCompaniesByLocation(city, district, neighborhood))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code") // "code" 프로퍼티(getter)를 통해 값을 추출
+                .isEqualTo(ErrorStatus.NO_SEARCH_RESULT); // 예외 내부의 errorStatus 검증
+
+        verify(companyRepository).findByAddressCityAndAddressDistrictAndAddressNeighborhood(city, district, neighborhood);
+    }
+
 }


### PR DESCRIPTION
- 회사명 검색으로 산재 이력 회사 검색 가능
- 선택한 주소 기준 검색으로 산재 이력 회사 검색 가능
- global 패키지에 api 응답 통일 및 예외 처리 구현
- service 계층 단위 테스트 통과